### PR TITLE
fix item duplication when place item

### DIFF
--- a/src/io/github/yodalee/FastBuild/FastBuild.java
+++ b/src/io/github/yodalee/FastBuild/FastBuild.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.entity.Player;
-import org.bukkit.configuration.file.FileConfiguration;
 
 /* fastbuild plugin by Yodalee
  */

--- a/src/io/github/yodalee/FastBuild/listeners/FastBuildBreakListener.java
+++ b/src/io/github/yodalee/FastBuild/listeners/FastBuildBreakListener.java
@@ -17,7 +17,6 @@ import org.bukkit.entity.ExperienceOrb;
 import org.bukkit.entity.Player;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.Listener;
@@ -26,7 +25,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
-@SuppressWarnings("unused")
 public class FastBuildBreakListener implements Listener {
   public FastBuild plugin;
   public FastBuildBreakListener (FastBuild instance){
@@ -61,7 +59,6 @@ public class FastBuildBreakListener implements Listener {
   //create exp at block location depends on block
   private void createExps(Player player, Block block, Material mat){
     World world = block.getWorld();
-    ExperienceOrb orb = null;
     int exp;
     switch (mat) {
       case COAL_ORE:
@@ -161,7 +158,7 @@ public class FastBuildBreakListener implements Listener {
     Block block = event.getBlock();
     Block nextBlock = null;
     Material originType = block.getType();
-    ItemStack tool = player.getItemInHand();
+    ItemStack tool = player.getInventory().getItemInMainHand();
 
     int n = plugin.getn(player.getName());
     boolean isCreative = (player.getGameMode() == GameMode.CREATIVE);

--- a/src/io/github/yodalee/FastBuild/listeners/FastBuildPlaceListener.java
+++ b/src/io/github/yodalee/FastBuild/listeners/FastBuildPlaceListener.java
@@ -5,16 +5,16 @@ import io.github.yodalee.FastBuild.FastBuild;
 import java.lang.Math;
 
 import org.bukkit.GameMode;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
-@SuppressWarnings("unused")
 public class FastBuildPlaceListener implements Listener {
   public FastBuild plugin;
   public FastBuildPlaceListener (FastBuild instance){
@@ -25,13 +25,14 @@ public class FastBuildPlaceListener implements Listener {
   }
 
   @SuppressWarnings("deprecation")
-  @EventHandler
+@EventHandler
   public void onPlace(final BlockPlaceEvent event) {
     if (!event.canBuild()) {
       return;
     } 
     Player player = event.getPlayer();
-	Block block = event.getBlockPlaced();
+    EquipmentSlot hand = event.getHand();
+    Block block = event.getBlockPlaced();
     Block againstBlock = event.getBlockAgainst();
     BlockFace face = againstBlock.getFace(block);
     Block nextBlock = null;
@@ -74,7 +75,12 @@ public class FastBuildPlaceListener implements Listener {
     // reduce itemStack in hand
     if (player.getGameMode() != GameMode.CREATIVE && block.getType() == stackInHand.getType()) {
       stackInHand.setAmount(stackInHand.getAmount() - reallyBuild);
-      player.setItemInHand(stackInHand);
+      PlayerInventory inventory = player.getInventory();
+      if (hand == EquipmentSlot.HAND) {
+        inventory.setItemInMainHand(stackInHand);
+      } else if (hand == EquipmentSlot.OFF_HAND) {
+    	 inventory.setItemInOffHand(stackInHand);
+      }
     } 
   }
 }


### PR DESCRIPTION
Close #2
minecraft add secondary hand since 1.9
replace old interface setItemInHand with new interface
setItemInMainHand to prevent item duplication

cc @johnjohnlin
